### PR TITLE
Fix Dataset identifier datatype & thesauri URI

### DIFF
--- a/release/dcatapvl.jsonld
+++ b/release/dcatapvl.jsonld
@@ -1764,7 +1764,7 @@
             "rdfs:comment": "codelist restriction",
             "sh:property": {
               "sh:class": "skos:ConceptScheme",
-              "sh:hasValue": "https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/levensfase.ttl",
+              "sh:hasValue": "https://data.vlaanderen.be/id/conceptscheme/levensfase",
               "sh:minCount": "1",
               "sh:nodeKind": "sh:IRI",
               "sh:path": "skos:inScheme"
@@ -1774,7 +1774,7 @@
           "sh:path": "http://data.vlaanderen.be/ns/metadata-dcat#levensfase",
           "sh:severity": "sh:Warning",
           "vl:message": {
-            "nl": "Enkel waarden uit codelijst <https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/levensfase.ttl> verwacht voor levensfase"
+            "nl": "Enkel waarden uit codelijst <https://data.vlaanderen.be/id/conceptscheme/levensfase> verwacht voor levensfase"
           },
           "vl:rule": ""
         },
@@ -1952,7 +1952,7 @@
             "rdfs:comment": "codelist restriction",
             "sh:property": {
               "sh:class": "skos:ConceptScheme",
-              "sh:hasValue": "https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/ontwikkelingstoestand.ttl",
+              "sh:hasValue": "https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand",
               "sh:minCount": "1",
               "sh:nodeKind": "sh:IRI",
               "sh:path": "skos:inScheme"
@@ -1962,7 +1962,7 @@
           "sh:path": "http://data.vlaanderen.be/ns/metadata-dcat#ontwikkelingstoestand",
           "sh:severity": "sh:Warning",
           "vl:message": {
-            "nl": "Enkel waarden uit codelijst <https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/ontwikkelingstoestand.ttl> verwacht voor ontwikkelingstoestand"
+            "nl": "Enkel waarden uit codelijst <https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand> verwacht voor ontwikkelingstoestand"
           },
           "vl:rule": ""
         },
@@ -2577,7 +2577,7 @@
         {
           "@id": "https://data.vlaanderen.be/shacl/DCAT-AP-VL#DatasetShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d",
           "rdfs:seeAlso": "https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/ontwerpstandaard/2021-06-27#Dataset%3Aidentificator",
-          "sh:class": "http://www.w3.org/ns/adms#Identifier",
+          "sh:datatype": "http://www.w3.org/2000/01/rdf-schema#Literal",
           "sh:description": {
             "nl": "De unieke identificator van de dataset."
           },
@@ -2586,7 +2586,7 @@
           },
           "sh:path": "http://purl.org/dc/terms/identifier",
           "vl:message": {
-            "nl": "De range van identificator moet van het type <http://www.w3.org/ns/adms#Identifier> zijn."
+            "nl": "De range van identificator moet van het type <http://www.w3.org/2000/01/rdf-schema#Literal> zijn."
           },
           "vl:rule": ""
         },
@@ -2872,7 +2872,7 @@
             "rdfs:comment": "codelist restriction",
             "sh:property": {
               "sh:class": "skos:ConceptScheme",
-              "sh:hasValue": "https://publications.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/access-right",
+              "sh:hasValue": "http://publications.europa.eu/resource/authority/access-right",
               "sh:minCount": "1",
               "sh:nodeKind": "sh:IRI",
               "sh:path": "skos:inScheme"
@@ -2882,7 +2882,7 @@
           "sh:path": "http://purl.org/dc/terms/accessRights",
           "sh:severity": "sh:Warning",
           "vl:message": {
-            "nl": "Enkel waarden uit codelijst <https://publications.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/access-right> verwacht voor toegankelijkheid"
+            "nl": "Enkel waarden uit codelijst <http://publications.europa.eu/resource/authority/access-right> verwacht voor toegankelijkheid"
           },
           "vl:rule": ""
         },
@@ -3428,7 +3428,7 @@
             "rdfs:comment": "codelist restriction",
             "sh:property": {
               "sh:class": "skos:ConceptScheme",
-              "sh:hasValue": "https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/",
+              "sh:hasValue": "https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden",
               "sh:minCount": "1",
               "sh:nodeKind": "sh:IRI",
               "sh:path": "skos:inScheme"
@@ -3438,7 +3438,7 @@
           "sh:path": "http://data.vlaanderen.be/ns/metadata-dcat#statuut",
           "sh:severity": "sh:Warning",
           "vl:message": {
-            "nl": "Enkel waarden uit codelijst <https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden/> verwacht voor statuut"
+            "nl": "Enkel waarden uit codelijst <https://metadata.vlaanderen.be/id/GDI-Vlaanderen-Trefwoorden> verwacht voor statuut"
           },
           "vl:rule": ""
         },

--- a/release/metadata_dcat.jsonld
+++ b/release/metadata_dcat.jsonld
@@ -1748,7 +1748,7 @@
             "rdfs:comment": "codelist restriction",
             "sh:property": {
               "sh:class": "skos:ConceptScheme",
-              "sh:hasValue": "https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/levensfase.ttl",
+              "sh:hasValue": "https://data.vlaanderen.be/id/conceptscheme/levensfase",
               "sh:minCount": "1",
               "sh:nodeKind": "sh:IRI",
               "sh:path": "skos:inScheme"
@@ -1758,7 +1758,7 @@
           "sh:path": "http://data.vlaanderen.be/ns/metadata-dcat#levensfase",
           "sh:severity": "sh:Warning",
           "vl:message": {
-            "nl": "Enkel waarden uit codelijst <https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/levensfase.ttl> verwacht voor levensfase"
+            "nl": "Enkel waarden uit codelijst <https://data.vlaanderen.be/id/conceptscheme/levensfase> verwacht voor levensfase"
           },
           "vl:rule": ""
         },
@@ -1920,7 +1920,7 @@
             "rdfs:comment": "codelist restriction",
             "sh:property": {
               "sh:class": "skos:ConceptScheme",
-              "sh:hasValue": "https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/ontwikkelingstoestand.ttl",
+              "sh:hasValue": "https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand",
               "sh:minCount": "1",
               "sh:nodeKind": "sh:IRI",
               "sh:path": "skos:inScheme"
@@ -1930,7 +1930,7 @@
           "sh:path": "http://data.vlaanderen.be/ns/metadata-dcat#ontwikkelingstoestand",
           "sh:severity": "sh:Warning",
           "vl:message": {
-            "nl": "Enkel waarden uit codelijst <https://github.com/Informatievlaanderen/OSLOthema-metadataVoorServices/raw/master/codelijsten/ontwikkelingstoestand.ttl> verwacht voor ontwikkelingstoestand"
+            "nl": "Enkel waarden uit codelijst <https://data.vlaanderen.be/id/conceptscheme/ontwikkelingstoestand> verwacht voor ontwikkelingstoestand"
           },
           "vl:rule": ""
         },
@@ -2545,7 +2545,7 @@
         {
           "@id": "https://data.vlaanderen.be/shacl/metadata_dcat#DatasetShape/05134c4e7c34157d6f7ac1128713a08418e0fe7d",
           "rdfs:seeAlso": "https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2021-04-22#Dataset%3Aidentificator",
-          "sh:class": "http://www.w3.org/ns/adms#Identifier",
+          "sh:datatype": "http://www.w3.org/2000/01/rdf-schema#Literal",
           "sh:description": {
             "nl": "De unieke identificator van de dataset."
           },
@@ -2554,7 +2554,7 @@
           },
           "sh:path": "http://purl.org/dc/terms/identifier",
           "vl:message": {
-            "nl": "De range van identificator moet van het type <http://www.w3.org/ns/adms#Identifier> zijn."
+            "nl": "De range van identificator moet van het type <http://www.w3.org/2000/01/rdf-schema#Literal> zijn."
           },
           "vl:rule": ""
         },
@@ -2840,7 +2840,7 @@
             "rdfs:comment": "codelist restriction",
             "sh:property": {
               "sh:class": "skos:ConceptScheme",
-              "sh:hasValue": "https://publications.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/access-right",
+              "sh:hasValue": "http://publications.europa.eu/resource/authority/access-right",
               "sh:minCount": "1",
               "sh:nodeKind": "sh:IRI",
               "sh:path": "skos:inScheme"
@@ -2850,7 +2850,7 @@
           "sh:path": "http://purl.org/dc/terms/accessRights",
           "sh:severity": "sh:Warning",
           "vl:message": {
-            "nl": "Enkel waarden uit codelijst <https://publications.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/access-right> verwacht voor toegankelijkheid"
+            "nl": "Enkel waarden uit codelijst <http://publications.europa.eu/resource/authority/access-right> verwacht voor toegankelijkheid"
           },
           "vl:rule": ""
         },


### PR DESCRIPTION
Hi @bertvannuffelen 
Here are some fixes for the SHACL spec.
I updated the URI of some thesauri as well as changing the rule for the Dataset identifier to be a literal and not a adms:Identifier.
